### PR TITLE
[ORG] USA-UDACITY: Update keras RNG logic to use tf.random.Generator if possible.

### DIFF
--- a/keras/api/golden/v1/tensorflow.keras.layers.-gaussian-dropout.pbtxt
+++ b/keras/api/golden/v1/tensorflow.keras.layers.-gaussian-dropout.pbtxt
@@ -129,7 +129,7 @@ tf_class {
   }
   member_method {
     name: "__init__"
-    argspec: "args=[\'self\', \'rate\'], varargs=None, keywords=kwargs, defaults=None"
+    argspec: "args=[\'self\', \'rate\', \'seed\'], varargs=None, keywords=kwargs, defaults=[\'None\'], "
   }
   member_method {
     name: "add_loss"

--- a/keras/api/golden/v1/tensorflow.keras.layers.-gaussian-noise.pbtxt
+++ b/keras/api/golden/v1/tensorflow.keras.layers.-gaussian-noise.pbtxt
@@ -129,7 +129,7 @@ tf_class {
   }
   member_method {
     name: "__init__"
-    argspec: "args=[\'self\', \'stddev\'], varargs=None, keywords=kwargs, defaults=None"
+    argspec: "args=[\'self\', \'stddev\', \'seed\'], varargs=None, keywords=kwargs, defaults=[\'None\'], "
   }
   member_method {
     name: "add_loss"

--- a/keras/api/golden/v2/tensorflow.keras.layers.-gaussian-dropout.pbtxt
+++ b/keras/api/golden/v2/tensorflow.keras.layers.-gaussian-dropout.pbtxt
@@ -129,7 +129,7 @@ tf_class {
   }
   member_method {
     name: "__init__"
-    argspec: "args=[\'self\', \'rate\'], varargs=None, keywords=kwargs, defaults=None"
+    argspec: "args=[\'self\', \'rate\', \'seed\'], varargs=None, keywords=kwargs, defaults=[\'None\'], "
   }
   member_method {
     name: "add_loss"

--- a/keras/api/golden/v2/tensorflow.keras.layers.-gaussian-noise.pbtxt
+++ b/keras/api/golden/v2/tensorflow.keras.layers.-gaussian-noise.pbtxt
@@ -129,7 +129,7 @@ tf_class {
   }
   member_method {
     name: "__init__"
-    argspec: "args=[\'self\', \'stddev\'], varargs=None, keywords=kwargs, defaults=None"
+    argspec: "args=[\'self\', \'stddev\', \'seed\'], varargs=None, keywords=kwargs, defaults=[\'None\'], "
   }
   member_method {
     name: "add_loss"

--- a/keras/initializers/initializers_test.py
+++ b/keras/initializers/initializers_test.py
@@ -59,17 +59,22 @@ class KerasInitializersTest(tf.test.TestCase):
 
   def _runner(self, init, shape, target_mean=None, target_std=None,
               target_max=None, target_min=None):
+    # The global seed is set so that we can get the same random streams between
+    # eager and graph mode when stateful op is used.
+    tf.random.set_seed(1337)
     variable = backend.variable(init(shape))
     output = backend.get_value(variable)
     # Test serialization (assumes deterministic behavior).
     config = init.get_config()
     reconstructed_init = init.__class__.from_config(config)
+
+    tf.random.set_seed(1337)
     variable = backend.variable(reconstructed_init(shape))
     output_2 = backend.get_value(variable)
     self.assertAllClose(output, output_2, atol=1e-4)
 
   def test_uniform(self):
-    tensor_shape = (9, 6, 7)
+    tensor_shape = (3, 2, 3)
     with self.cached_session():
       self._runner(
           initializers.RandomUniformV2(minval=-1, maxval=1, seed=124),

--- a/keras/initializers/initializers_v2.py
+++ b/keras/initializers/initializers_v2.py
@@ -18,7 +18,6 @@
 import math
 from keras import backend
 import tensorflow.compat.v2 as tf
-from tensorflow.python.ops import stateless_random_ops
 from tensorflow.python.util.tf_export import keras_export
 
 _PARTITION_SHAPE = 'partition_shape'
@@ -254,15 +253,18 @@ class RandomUniform(Initializer):
       random values to generate (inclusive).
     maxval: A python scalar or a scalar tensor. Upper bound of the range of
       random values to generate (exclusive).
-    seed: A Python integer. An initializer created with a given seed will
-      always produce the same random tensor for a given shape and dtype.
+    seed: A Python integer. Used to create random seeds. See
+      `tf.compat.v1.set_random_seed` for behavior. Note that seeded
+      initializer will not produce same random values across multiple calls,
+      but multiple initializers will produce same sequence when constructed with
+      same seed value.
   """
 
   def __init__(self, minval=-0.05, maxval=0.05, seed=None):
     self.minval = minval
     self.maxval = maxval
     self.seed = seed
-    self._random_generator = _RandomGenerator(seed)
+    self._random_generator = backend.RandomGenerator(seed)
 
   def __call__(self, shape, dtype=None, **kwargs):
     """Returns a tensor object initialized as specified by the initializer.
@@ -317,15 +319,18 @@ class RandomNormal(Initializer):
       generate.
     stddev: a python scalar or a scalar tensor. Standard deviation of the random
       values to generate.
-    seed: A Python integer. An initializer created with a given seed will
-      always produce the same random tensor for a given shape and dtype.
+    seed: A Python integer. Used to create random seeds. See
+      `tf.compat.v1.set_random_seed` for behavior. Note that seeded
+      initializer will not produce same random values across multiple calls,
+      but multiple initializers will produce same sequence when constructed with
+      same seed value.
   """
 
   def __init__(self, mean=0.0, stddev=0.05, seed=None):
     self.mean = mean
     self.stddev = stddev
     self.seed = seed
-    self._random_generator = _RandomGenerator(seed)
+    self._random_generator = backend.RandomGenerator(seed)
 
   def __call__(self, shape, dtype=None, **kwargs):
     """Returns a tensor object initialized to random normal values.
@@ -382,15 +387,18 @@ class TruncatedNormal(Initializer):
       to generate.
     stddev: a python scalar or a scalar tensor. Standard deviation of the
       random values to generate before truncation.
-    seed: A Python integer. An initializer created with a given seed will
-      always produce the same random tensor for a given shape and dtype.
+    seed: A Python integer. Used to create random seeds. See
+      `tf.compat.v1.set_random_seed` for behavior. Note that seeded
+      initializer will not produce same random values across multiple calls,
+      but multiple initializers will produce same sequence when constructed with
+      same seed value.
   """
 
   def __init__(self, mean=0.0, stddev=0.05, seed=None):
     self.mean = mean
     self.stddev = stddev
     self.seed = seed
-    self._random_generator = _RandomGenerator(seed)
+    self._random_generator = backend.RandomGenerator(seed)
 
   def __call__(self, shape, dtype=None, **kwargs):
     """Returns a tensor object initialized to random normal values (truncated).
@@ -456,8 +464,11 @@ class VarianceScaling(Initializer):
     mode: One of "fan_in", "fan_out", "fan_avg".
     distribution: Random distribution to use. One of "truncated_normal",
       "untruncated_normal" and  "uniform".
-    seed: A Python integer. An initializer created with a given seed will
-      always produce the same random tensor for a given shape and dtype.
+    seed: A Python integer. Used to create random seeds. See
+      `tf.compat.v1.set_random_seed` for behavior. Note that seeded
+      initializer will not produce same random values across multiple calls,
+      but multiple initializers will produce same sequence when constructed with
+      same seed value.
   """
 
   def __init__(self,
@@ -486,7 +497,7 @@ class VarianceScaling(Initializer):
     self.mode = mode
     self.distribution = distribution
     self.seed = seed
-    self._random_generator = _RandomGenerator(seed)
+    self._random_generator = backend.RandomGenerator(seed)
 
   def __call__(self, shape, dtype=None, **kwargs):
     """Returns a tensor object initialized as specified by the initializer.
@@ -562,18 +573,20 @@ class Orthogonal(Initializer):
 
   Args:
     gain: multiplicative factor to apply to the orthogonal matrix
-    seed: A Python integer. An initializer created with a given seed will
-      always produce the same random tensor for a given shape and dtype.
+    seed: A Python integer. Used to create random seeds. See
+      `tf.compat.v1.set_random_seed` for behavior. Note that seeded
+      initializer will not produce same random values across multiple calls,
+      but multiple initializers will produce same sequence when constructed with
+      same seed value.
 
   References:
-      [Saxe et al., 2014](https://openreview.net/forum?id=_wzZwKpTDF_9C)
-      ([pdf](https://arxiv.org/pdf/1312.6120.pdf))
+    - [Saxe et al., 2014](https://openreview.net/forum?id=_wzZwKpTDF_9C)
   """
 
   def __init__(self, gain=1.0, seed=None):
     self.gain = gain
     self.seed = seed
-    self._random_generator = _RandomGenerator(seed)
+    self._random_generator = backend.RandomGenerator(seed)
 
   def __call__(self, shape, dtype=None, **kwargs):
     """Returns a tensor object initialized to an orthogonal matrix.
@@ -691,12 +704,14 @@ class GlorotUniform(VarianceScaling):
   >>> layer = tf.keras.layers.Dense(3, kernel_initializer=initializer)
 
   Args:
-    seed: A Python integer. An initializer created with a given seed will
-      always produce the same random tensor for a given shape and dtype.
+    seed: A Python integer. Used to create random seeds. See
+      `tf.compat.v1.set_random_seed` for behavior. Note that seeded
+      initializer will not produce same random values across multiple calls,
+      but multiple initializers will produce same sequence when constructed with
+      same seed value.
 
   References:
-      [Glorot et al., 2010](http://proceedings.mlr.press/v9/glorot10a.html)
-      ([pdf](http://jmlr.org/proceedings/papers/v9/glorot10a/glorot10a.pdf))
+    - [Glorot et al., 2010](http://proceedings.mlr.press/v9/glorot10a.html)
   """
 
   def __init__(self, seed=None):
@@ -735,12 +750,14 @@ class GlorotNormal(VarianceScaling):
   >>> layer = tf.keras.layers.Dense(3, kernel_initializer=initializer)
 
   Args:
-    seed: A Python integer. An initializer created with a given seed will
-      always produce the same random tensor for a given shape and dtype.
+    seed: A Python integer. Used to create random seeds. See
+      `tf.compat.v1.set_random_seed` for behavior. Note that seeded
+      initializer will not produce same random values across multiple calls,
+      but multiple initializers will produce same sequence when constructed with
+      same seed value.
 
   References:
-      [Glorot et al., 2010](http://proceedings.mlr.press/v9/glorot10a.html)
-      ([pdf](http://jmlr.org/proceedings/papers/v9/glorot10a/glorot10a.pdf))
+    - [Glorot et al., 2010](http://proceedings.mlr.press/v9/glorot10a.html)
   """
 
   def __init__(self, seed=None):
@@ -782,16 +799,14 @@ class LecunNormal(VarianceScaling):
   >>> layer = tf.keras.layers.Dense(3, kernel_initializer=initializer)
 
   Args:
-    seed: A Python integer. Used to seed the random generator.
+    seed: A Python integer. Used to create random seeds. See
+      `tf.compat.v1.set_random_seed` for behavior. Note that seeded
+      initializer will not produce same random values across multiple calls,
+      but multiple initializers will produce same sequence when constructed with
+      same seed value.
 
   References:
-      - Self-Normalizing Neural Networks,
-      [Klambauer et al., 2017]
-      (https://papers.nips.cc/paper/6698-self-normalizing-neural-networks)
-      ([pdf]
-      (https://papers.nips.cc/paper/6698-self-normalizing-neural-networks.pdf))
-      - Efficient Backprop,
-      [Lecun et al., 1998](http://yann.lecun.com/exdb/publis/pdf/lecun-98b.pdf)
+    - [Klambauer et al., 2017](https://arxiv.org/abs/1706.02515)
   """
 
   def __init__(self, seed=None):
@@ -826,15 +841,14 @@ class LecunUniform(VarianceScaling):
   >>> layer = tf.keras.layers.Dense(3, kernel_initializer=initializer)
 
   Args:
-    seed: A Python integer. An initializer created with a given seed will
-      always produce the same random tensor for a given shape and dtype.
+    seed: A Python integer. Used to create random seeds. See
+      `tf.compat.v1.set_random_seed` for behavior. Note that seeded
+      initializer will not produce same random values across multiple calls,
+      but multiple initializers will produce same sequence when constructed with
+      same seed value.
 
   References:
-      - Self-Normalizing Neural Networks,
-      [Klambauer et al., 2017](https://papers.nips.cc/paper/6698-self-normalizing-neural-networks) # pylint: disable=line-too-long
-      ([pdf](https://papers.nips.cc/paper/6698-self-normalizing-neural-networks.pdf))
-      - Efficient Backprop,
-      [Lecun et al., 1998](http://yann.lecun.com/exdb/publis/pdf/lecun-98b.pdf)
+    - [Klambauer et al., 2017](https://arxiv.org/abs/1706.02515)
   """
 
   def __init__(self, seed=None):
@@ -869,12 +883,14 @@ class HeNormal(VarianceScaling):
   >>> layer = tf.keras.layers.Dense(3, kernel_initializer=initializer)
 
   Args:
-    seed: A Python integer. An initializer created with a given seed will
-      always produce the same random tensor for a given shape and dtype.
+    seed: A Python integer. Used to create random seeds. See
+      `tf.compat.v1.set_random_seed` for behavior. Note that seeded
+      initializer will not produce same random values across multiple calls,
+      but multiple initializers will produce same sequence when constructed with
+      same seed value.
 
   References:
-      [He et al., 2015](https://www.cv-foundation.org/openaccess/content_iccv_2015/html/He_Delving_Deep_into_ICCV_2015_paper.html) # pylint: disable=line-too-long
-      ([pdf](https://www.cv-foundation.org/openaccess/content_iccv_2015/papers/He_Delving_Deep_into_ICCV_2015_paper.pdf))
+    - [He et al., 2015](https://arxiv.org/abs/1502.01852)
   """
 
   def __init__(self, seed=None):
@@ -909,12 +925,14 @@ class HeUniform(VarianceScaling):
   >>> layer = tf.keras.layers.Dense(3, kernel_initializer=initializer)
 
   Args:
-    seed: A Python integer. An initializer created with a given seed will
-      always produce the same random tensor for a given shape and dtype.
+    seed: A Python integer. Used to create random seeds. See
+      `tf.compat.v1.set_random_seed` for behavior. Note that seeded
+      initializer will not produce same random values across multiple calls,
+      but multiple initializers will produce same sequence when constructed with
+      same seed value.
 
   References:
-      [He et al., 2015](https://www.cv-foundation.org/openaccess/content_iccv_2015/html/He_Delving_Deep_into_ICCV_2015_paper.html) # pylint: disable=line-too-long
-      ([pdf](https://www.cv-foundation.org/openaccess/content_iccv_2015/papers/He_Delving_Deep_into_ICCV_2015_paper.pdf))
+    - [He et al., 2015](https://arxiv.org/abs/1502.01852)
   """
 
   def __init__(self, seed=None):
@@ -949,45 +967,6 @@ def _assert_float_dtype(dtype):
   if not dtype.is_floating:
     raise ValueError(f'Expected floating point type, got {dtype}.')
   return dtype
-
-
-class _RandomGenerator:
-  """Random generator that selects appropriate random ops."""
-
-  def __init__(self, seed=None):
-    super(_RandomGenerator, self).__init__()
-    if seed is not None:
-      # Stateless random ops requires 2-int seed.
-      self.seed = [seed, 0]
-    else:
-      self.seed = None
-
-  def random_normal(self, shape, mean=0.0, stddev=1, dtype=tf.float32):
-    """A deterministic random normal if seed is passed."""
-    if self.seed:
-      op = tf.random.stateless_normal
-    else:
-      op = tf.random.normal
-    return op(
-        shape=shape, mean=mean, stddev=stddev, dtype=dtype, seed=self.seed)
-
-  def random_uniform(self, shape, minval, maxval, dtype):
-    """A deterministic random uniform if seed is passed."""
-    if self.seed:
-      op = stateless_random_ops.stateless_random_uniform
-    else:
-      op = tf.random.uniform
-    return op(
-        shape=shape, minval=minval, maxval=maxval, dtype=dtype, seed=self.seed)
-
-  def truncated_normal(self, shape, mean, stddev, dtype):
-    """A deterministic truncated normal if seed is passed."""
-    if self.seed:
-      op = tf.random.stateless_truncated_normal
-    else:
-      op = tf.random.truncated_normal
-    return op(
-        shape=shape, mean=mean, stddev=stddev, dtype=dtype, seed=self.seed)
 
 
 def _compute_fans(shape):

--- a/keras/integration_test/gradients_test.py
+++ b/keras/integration_test/gradients_test.py
@@ -101,9 +101,9 @@ class GradientsTest(tf.test.TestCase):
     self.assertAllClose(eager_result, function_result)
     backprop_result, numeric_result = tf.test.compute_gradient(
         m, [inp], delta=1e-3)
-    self.assertAllClose(numeric_result, backprop_result, rtol=1e-2)
+    self.assertAllClose(numeric_result, backprop_result, atol=1e-3)
     self.assertAllClose(tf.reshape(numeric_result, [-1]),
-                        tf.reshape(eager_result, [-1]), rtol=1e-2)
+                        tf.reshape(eager_result, [-1]), atol=1e-3)
 
   def testEmbeddingLookupGradientsHaveKnownShape(self):
 

--- a/keras/layers/kernelized.py
+++ b/keras/layers/kernelized.py
@@ -192,8 +192,7 @@ class RandomFourierFeatures(base_layer.Layer):
         name='bias',
         shape=(self.output_dim,),
         dtype=tf.float32,
-        initializer=tf.compat.v1.random_uniform_initializer(
-            minval=0.0, maxval=2 * np.pi, dtype=tf.float32),
+        initializer=initializers.RandomUniform(minval=0.0, maxval=2 * np.pi),
         trainable=False)
 
     if self.scale is None:
@@ -247,10 +246,9 @@ def _get_random_features_initializer(initializer, shape):
   random_features_initializer = initializer
   if isinstance(initializer, str):
     if initializer.lower() == 'gaussian':
-      random_features_initializer = tf.compat.v1.random_normal_initializer(
-          stddev=1.0)
+      random_features_initializer = initializers.RandomNormal(stddev=1.0)
     elif initializer.lower() == 'laplacian':
-      random_features_initializer = tf.compat.v1.constant_initializer(
+      random_features_initializer = initializers.Constant(
           _get_cauchy_samples(loc=0.0, scale=1.0, shape=shape))
 
     else:

--- a/keras/layers/kernelized_test.py
+++ b/keras/layers/kernelized_test.py
@@ -342,10 +342,10 @@ class RandomFourierFeaturesTest(tf.test.TestCase, parameterized.TestCase):
       with self.cached_session() as sess:
         keras_backend._initialize_variables(sess)
         abs_error_eval = sess.run([abs_error])
-        self.assertGreater(abs_error_eval[0][0], 0.05)
+        self.assertGreater(abs_error_eval[0][0], 0.01)
         self.assertLess(abs_error_eval[0][0], 0.5)
     else:
-      self.assertGreater(abs_error, 0.05)
+      self.assertGreater(abs_error, 0.01)
       self.assertLess(abs_error, 0.5)
 
   @parameterized.named_parameters(

--- a/keras/layers/preprocessing/image_preprocessing_test.py
+++ b/keras/layers/preprocessing/image_preprocessing_test.py
@@ -24,9 +24,6 @@ from keras.layers.preprocessing import image_preprocessing
 import numpy as np
 import tensorflow.compat.v2 as tf
 # pylint: disable=g-direct-tensorflow-import
-from tensorflow.python.distribute.mirrored_strategy import MirroredStrategy
-from tensorflow.python.ops import gen_stateful_random_ops
-from tensorflow.python.ops import gen_stateless_random_ops_v2
 from tensorflow.python.ops import stateless_random_ops
 
 
@@ -309,12 +306,10 @@ class RandomCropTest(keras_parameterized.TestCase):
     height_offset = np.random.randint(low=0, high=3)
     width_offset = np.random.randint(low=0, high=5)
     mock_offset = [0, height_offset, width_offset, 0]
-    with tf.compat.v1.test.mock.patch.object(
-        stateless_random_ops,
-        'stateless_random_uniform',
-        return_value=mock_offset):
-      with testing_utils.use_gpu():
-        layer = image_preprocessing.RandomCrop(height, width)
+    with testing_utils.use_gpu():
+      layer = image_preprocessing.RandomCrop(height, width)
+      with tf.compat.v1.test.mock.patch.object(
+          layer._random_generator, 'random_uniform', return_value=mock_offset):
         inp = np.random.random((12, 5, 8, 3))
         actual_output = layer(inp, training=1)
         expected_output = inp[:, height_offset:(height_offset + height),
@@ -373,12 +368,12 @@ class RandomCropTest(keras_parameterized.TestCase):
     np.random.seed(1337)
     inp = np.random.random((16, 16, 3))
     mock_offset = [2, 2, 0]
-    with tf.compat.v1.test.mock.patch.object(
-        stateless_random_ops,
-        'stateless_random_uniform',
-        return_value=mock_offset):
-      with testing_utils.use_gpu():
-        layer = image_preprocessing.RandomCrop(8, 8)
+    with testing_utils.use_gpu():
+      layer = image_preprocessing.RandomCrop(8, 8)
+      with tf.compat.v1.test.mock.patch.object(
+          layer._random_generator,
+          'random_uniform',
+          return_value=mock_offset):
         actual_output = layer(inp, training=1)
         self.assertAllClose(inp[2:10, 2:10, :], actual_output)
 
@@ -1200,7 +1195,7 @@ class RandomRotationTest(keras_parameterized.TestCase):
     """Tests that RandomRotation can be created within distribution strategies."""
     input_images = np.random.random((2, 5, 8, 3)).astype(np.float32)
     with testing_utils.use_gpu():
-      strat = MirroredStrategy(devices=['cpu', 'gpu'])
+      strat = tf.distribute.MirroredStrategy(devices=['cpu', 'gpu'])
       with strat.scope():
         layer = image_preprocessing.RandomRotation(.5)
         output = strat.run(lambda: layer(input_images, training=True))
@@ -1370,18 +1365,14 @@ class RandomHeightTest(keras_parameterized.TestCase):
 
   def test_valid_random_height(self):
     # need (maxval - minval) * rnd + minval = 0.6
-    mock_factor = 0
-    with tf.compat.v1.test.mock.patch.object(
-        gen_stateful_random_ops, 'stateful_uniform', return_value=mock_factor):
+    mock_factor = 0.6
+    with testing_utils.use_gpu():
+      img = np.random.random((12, 5, 8, 3))
+      layer = image_preprocessing.RandomHeight(.4)
       with tf.compat.v1.test.mock.patch.object(
-          gen_stateless_random_ops_v2,
-          'stateless_random_uniform_v2',
-          return_value=mock_factor):
-        with testing_utils.use_gpu():
-          img = np.random.random((12, 5, 8, 3))
-          layer = image_preprocessing.RandomHeight(.4)
-          img_out = layer(img, training=True)
-          self.assertEqual(img_out.shape[1], 3)
+          layer._random_generator, 'random_uniform', return_value=mock_factor):
+        img_out = layer(img, training=True)
+        self.assertEqual(img_out.shape[1], 3)
 
   def test_random_height_longer_numeric(self):
     for dtype in (np.int64, np.float32):
@@ -1440,18 +1431,14 @@ class RandomHeightTest(keras_parameterized.TestCase):
 
   def test_unbatched_image(self):
     # need (maxval - minval) * rnd + minval = 0.6
-    mock_factor = 0
-    with tf.compat.v1.test.mock.patch.object(
-        gen_stateful_random_ops, 'stateful_uniform', return_value=mock_factor):
+    mock_factor = 0.6
+    with testing_utils.use_gpu():
+      img = np.random.random((5, 8, 3))
+      layer = image_preprocessing.RandomHeight(.4)
       with tf.compat.v1.test.mock.patch.object(
-          gen_stateless_random_ops_v2,
-          'stateless_random_uniform_v2',
-          return_value=mock_factor):
-        with testing_utils.use_gpu():
-          img = np.random.random((5, 8, 3))
-          layer = image_preprocessing.RandomHeight(.4)
-          img_out = layer(img, training=True)
-          self.assertEqual(img_out.shape[0], 3)
+          layer._random_generator, 'random_uniform', return_value=mock_factor):
+        img_out = layer(img, training=True)
+        self.assertEqual(img_out.shape[0], 3)
 
 
 @keras_parameterized.run_all_keras_modes(always_skip_v1=True)
@@ -1479,18 +1466,14 @@ class RandomWidthTest(keras_parameterized.TestCase):
 
   def test_valid_random_width(self):
     # need (maxval - minval) * rnd + minval = 0.6
-    mock_factor = 0
-    with tf.compat.v1.test.mock.patch.object(
-        gen_stateful_random_ops, 'stateful_uniform', return_value=mock_factor):
+    mock_factor = 0.6
+    with testing_utils.use_gpu():
+      img = np.random.random((12, 8, 5, 3))
+      layer = image_preprocessing.RandomWidth(.4)
       with tf.compat.v1.test.mock.patch.object(
-          gen_stateless_random_ops_v2,
-          'stateless_random_uniform_v2',
-          return_value=mock_factor):
-        with testing_utils.use_gpu():
-          img = np.random.random((12, 8, 5, 3))
-          layer = image_preprocessing.RandomWidth(.4)
-          img_out = layer(img, training=True)
-          self.assertEqual(img_out.shape[2], 3)
+          layer._random_generator, 'random_uniform', return_value=mock_factor):
+        img_out = layer(img, training=True)
+        self.assertEqual(img_out.shape[2], 3)
 
   def test_random_width_longer_numeric(self):
     for dtype in (np.int64, np.float32):
@@ -1548,18 +1531,14 @@ class RandomWidthTest(keras_parameterized.TestCase):
 
   def test_unbatched_image(self):
     # need (maxval - minval) * rnd + minval = 0.6
-    mock_factor = 0
-    with tf.compat.v1.test.mock.patch.object(
-        gen_stateful_random_ops, 'stateful_uniform', return_value=mock_factor):
+    mock_factor = 0.6
+    with testing_utils.use_gpu():
+      img = np.random.random((8, 5, 3))
+      layer = image_preprocessing.RandomWidth(.4)
       with tf.compat.v1.test.mock.patch.object(
-          gen_stateless_random_ops_v2,
-          'stateless_random_uniform_v2',
-          return_value=mock_factor):
-        with testing_utils.use_gpu():
-          img = np.random.random((8, 5, 3))
-          layer = image_preprocessing.RandomWidth(.4)
-          img_out = layer(img, training=True)
-          self.assertEqual(img_out.shape[1], 3)
+          layer._random_generator, 'random_uniform', return_value=mock_factor):
+        img_out = layer(img, training=True)
+        self.assertEqual(img_out.shape[1], 3)
 
 
 @keras_parameterized.run_all_keras_modes(always_skip_v1=True)

--- a/keras/optimizer_v2/learning_rate_schedule.py
+++ b/keras/optimizer_v2/learning_rate_schedule.py
@@ -18,6 +18,7 @@ import tensorflow.compat.v2 as tf
 
 import abc
 import math
+from keras import backend
 from keras.utils import generic_utils
 from tensorflow.python.util.tf_export import keras_export
 
@@ -950,6 +951,7 @@ class NoisyLinearCosineDecay(LearningRateSchedule):
       num_periods=0.5,
       alpha=0.0,
       beta=0.001,
+      seed=None,
       name=None):
     """Applies noisy linear cosine decay to the learning rate.
 
@@ -964,6 +966,7 @@ class NoisyLinearCosineDecay(LearningRateSchedule):
         See computation above.
       alpha: See computation above.
       beta: See computation above.
+      seed: Integer, optional random seed to enable deterministic behavior.
       name: String.  Optional name of the operation.  Defaults to
         'NoisyLinearCosineDecay'.
     """
@@ -976,7 +979,9 @@ class NoisyLinearCosineDecay(LearningRateSchedule):
     self.num_periods = num_periods
     self.alpha = alpha
     self.beta = beta
+    self.seed = seed
     self.name = name
+    self._random_generator = backend.RandomGenerator(seed)
 
   def __call__(self, step):
     with tf.name_scope(self.name or "NoisyLinearCosineDecay") as name:
@@ -997,7 +1002,7 @@ class NoisyLinearCosineDecay(LearningRateSchedule):
           tf.pow(1.0 + global_step_recomp, variance_decay))
       std = tf.sqrt(variance)
       noisy_linear_decayed = (
-          linear_decayed + tf.random.normal(
+          linear_decayed + self._random_generator.random_normal(
               linear_decayed.shape, stddev=std))
 
       completed_fraction = global_step_recomp / decay_steps
@@ -1019,7 +1024,8 @@ class NoisyLinearCosineDecay(LearningRateSchedule):
         "num_periods": self.num_periods,
         "alpha": self.alpha,
         "beta": self.beta,
-        "name": self.name
+        "seed": self.seed,
+        "name": self.name,
     }
 
 


### PR DESCRIPTION
This change also update the RNG behavior for initializer. The seeded initializer will no longer produce same random value across multiple calls. Instead, it will produce different value, and multiple initializer created with same seed will produce same sequences. This change will the make the seeded initializer behavior align between v1 and v2.

Keras was using stateful RNG op in various place when seed is not provided. The recommended approach in v2 is using tf.random.Generator which can be treat as a variable (seed) with stateless RNG op. This change make sure we use this new approach when seed is provided in v2, and also leave a flag to enforce the new approach, which has not been turn on yet. The new approach will be turned on when all the internal tests are fixed. V1 graph mode, the behavior is not change.

PiperOrigin-RevId: 392092094